### PR TITLE
increase muxado timeouts

### DIFF
--- a/proto/ext/heartbeat.go
+++ b/proto/ext/heartbeat.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	defaultHeartbeatInterval  = 3 * time.Second
-	defaultHeartbeatTolerance = 10 * time.Second
+	defaultHeartbeatTolerance = 60 * time.Second
 )
 
 type Heartbeat struct {

--- a/proto/stream.go
+++ b/proto/stream.go
@@ -13,7 +13,7 @@ import (
 
 var (
 	zeroTime         time.Time
-	resetRemoveDelay = 10 * time.Second
+	resetRemoveDelay = 30 * time.Second
 	closeError       = fmt.Errorf("Stream closed")
 )
 


### PR DESCRIPTION
we have nodes communicating across the great firewall of china, a 3 second
heartbeat is unreasonable. While connections will often make it past the GFC in
3 seconds, they will commonly take much longer than that. This can result in
people losing all of their sessions when the GFC hiccups. An extended timeout
caters to China a lot better.